### PR TITLE
Dp create initial data

### DIFF
--- a/loaddata.sql
+++ b/loaddata.sql
@@ -88,3 +88,12 @@ CREATE TABLE "Categories" (
 INSERT INTO Categories ('label') VALUES ('News');
 INSERT INTO Tags ('label') VALUES ('JavaScript');
 INSERT INTO Reactions ('label', 'image_url') VALUES ('happy', 'https://pngtree.com/so/happy');
+
+
+INSERT INTO Users ('first_name', 'last_name', 'email', 'bio', 'username', 'password', 'profile_image_url', 'created_on', 'active') VALUES ('Testy', 'Testerson', 'testing@tester.com', 'I am a dynamic placeholder bot who likes a stiff negroni and long walks on the beach', 'testrr42069', NULL, 2022-07-23 11:44:02.966793, 1);
+INSERT INTO Users ('first_name', 'last_name', 'email', 'bio', 'username', 'password', 'profile_image_url', 'created_on', 'active') VALUES ('Donny', 'Osmund', 'joe@jatatdc.com', 'I am maybe the most famous Mormon there is', 'donnyboi', NULL, 2022-07-24 11:44:02.966793, 1);
+
+INSERT INTO Posts 
+VALUES ('Donny', 'Osmund', 'joe@jatatdc.com', 'I am maybe the most famous Mormon there is', 'donnyboi', NULL, 2022-07-24 11:44:02.966793, 1);
+
+

--- a/loaddata.sql
+++ b/loaddata.sql
@@ -90,10 +90,53 @@ INSERT INTO Tags ('label') VALUES ('JavaScript');
 INSERT INTO Reactions ('label', 'image_url') VALUES ('happy', 'https://pngtree.com/so/happy');
 
 
-INSERT INTO Users ('first_name', 'last_name', 'email', 'bio', 'username', 'password', 'profile_image_url', 'created_on', 'active') VALUES ('Testy', 'Testerson', 'testing@tester.com', 'I am a dynamic placeholder bot who likes a stiff negroni and long walks on the beach', 'testrr42069', NULL, 2022-07-23 11:44:02.966793, 1);
-INSERT INTO Users ('first_name', 'last_name', 'email', 'bio', 'username', 'password', 'profile_image_url', 'created_on', 'active') VALUES ('Donny', 'Osmund', 'joe@jatatdc.com', 'I am maybe the most famous Mormon there is', 'donnyboi', NULL, 2022-07-24 11:44:02.966793, 1);
+-- RUN ALL OF THE BELOW TO DELETE ANY EXISTING USER DATA AND START US ALL OUT WITH IDENTICAL DATA
+-- WILL DELETE DATA FROM USERS AND THEN WRITE STARTER DATA FOR USERS, POSTS, CATEGORIES, TAGS, REACTIONS, COMMENTS
 
-INSERT INTO Posts 
-VALUES ('Donny', 'Osmund', 'joe@jatatdc.com', 'I am maybe the most famous Mormon there is', 'donnyboi', NULL, 2022-07-24 11:44:02.966793, 1);
+DROP TABLE Users;
+DELETE FROM Reactions;
+
+CREATE TABLE "Users" (
+  "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+  "first_name" varchar,
+  "last_name" varchar,
+  "email" varchar,
+  "bio" varchar,
+  "username" varchar,
+  "password" varchar,
+  "profile_image_url" varchar,
+  "created_on" date,
+  "active" bit
+);
+
+INSERT INTO `Categories` VALUES (null, 'Rants');
+INSERT INTO `Categories` VALUES (null, 'Self-Help');
+
+INSERT INTO `Tags` VALUES (null, 'Uplifting');
+INSERT INTO `Tags` VALUES (null, 'Instructional');
+INSERT INTO `Tags` VALUES (null, 'Demoralizing');
+
+INSERT INTO Reactions ('label', 'image_url') VALUES ('happy', 'https://freepngimg.com/thumb/emoji/47416-2-smiley-image-free-png-hq.png');
+INSERT INTO Reactions ('label', 'image_url') VALUES ('laugh-cry', 'https://freepngimg.com/thumb/emoji/5-2-face-with-tears-of-joy-emoji-png.png');
+INSERT INTO Reactions ('label', 'image_url') VALUES ('crying', 'https://freepngimg.com/thumb/emoji/11-2-loudly-crying-emoji-png.png');
+INSERT INTO Reactions ('label', 'image_url') VALUES ('fire', 'https://freepngimg.com/thumb/emoji/58685-apple-color-symbol-fire-shape-iphone-emoji.png');
+INSERT INTO Reactions ('label', 'image_url') VALUES ('pirate', 'https://freepngimg.com/thumb/emoji/65088-emoticon-piracy-smiley-pirate-emoji-png-image-high-quality.png');
+
+
+INSERT INTO Users ('first_name', 'last_name', 'email', 'bio', 'username', 'password', 'profile_image_url', 'created_on', 'active') VALUES ('Testy', 'Testerson', 'testing@tester.com', 'I am a dynamic placeholder bot who likes a stiff negroni and long walks on the beach', 'testrr42069', 'password', NULL, '2022-07-23 11:44:02.966793', 1);
+INSERT INTO Users ('first_name', 'last_name', 'email', 'bio', 'username', 'password', 'profile_image_url', 'created_on', 'active') VALUES ('Donny', 'Osmund', 'joe@jatatdc.com', 'I am maybe the most famous Mormon there is', 'donnyboi', 'password', NULL, '2022-07-24 11:44:02.966793', 1);
+
+INSERT INTO `Posts` VALUES (null, 1, 1, 'The Legend of Testy', '2022-07-25 11:44:02.966793', 'https://sjo.com/wp-content/uploads/2018/04/mountaintopview-540x280.jpg', 'This is the story of my climb from a simple data placeholder to an all-powerful oil and gas magnate', 1);
+INSERT INTO `Posts` VALUES (null, 2, 2, 'Sing it, sister', '2022-07-23 11:44:02.966793', 'https://media.wkyc.com/assets/WKYC/images/28739739-968e-4774-ac4f-3093aaec3870/28739739-968e-4774-ac4f-3093aaec3870_1140x641.jpg', 'I love my sister. But for the record, I am better.', 1);
+
+INSERT INTO PostTags ('post_id', 'tag_id') VALUES (1, 2);
+INSERT INTO PostTags ('post_id', 'tag_id') VALUES (1, 3);
+INSERT INTO PostTags ('post_id', 'tag_id') VALUES (2, 2);
+INSERT INTO PostTags ('post_id', 'tag_id') VALUES (2, 4);
+
+INSERT INTO Comments ('post_id', 'author_id', 'content') VALUES (1, 2, 'How inspiring!');
+INSERT INTO Comments ('post_id', 'author_id', 'content') VALUES (2, 1, 'How sassy!');
+
+
 
 


### PR DESCRIPTION
# Description

Fixes # Client-side # 2
https://github.com/nss-day-cohort-56/rare-python-server-cheese-shop/issues/2

Database update-- will delete existing user table and re-create it with 2 dummy data entries to make sure we're all starting from the same place. Also adds dummy data for posts, comments, categories, tags, posttags, and reactions. 
After doing this one update to standardize our databases I think we can add our own user data again as we like, in order to login, test new features etc.

# How Has This Been Tested?

- [X] Tested in my local loaddata.sql to confirm the correct info was added to DB.

To test, simply run all the commands that are under my comment in loaddata.sql. This should update your DB with all dummy data listed above.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
